### PR TITLE
updates for compatibility with stdlib 0.16

### DIFF
--- a/src/Data/List/All/Properties/Extra.agda
+++ b/src/Data/List/All/Properties/Extra.agda
@@ -1,7 +1,7 @@
 module Data.List.All.Properties.Extra {a}{A : Set a} where
 
 open import Relation.Binary.PropositionalEquality
-open import Data.Nat hiding (erase)
+open import Data.Nat
 open import Data.Fin
 open import Data.List as List hiding (reverse)
 open import Data.List.Any hiding (tail)
@@ -96,7 +96,7 @@ erase f [] = []
 erase f (px ∷ xs₁) = f px ∷ erase f xs₁
 
 pop₁ : ∀ {x : A}{p xs}{P : A → Set p} → All P (x ∷ xs) → P x × All P xs
-pop₁ st = head st , tail st
+pop₁ st = All.head st , All.tail st
 
 open import Data.List.Properties
 popₙ : ∀ (as : List A){p xs}{P : A → Set p} → All P (as ++ xs) → All P (List.reverse as) × All P xs

--- a/src/Data/List/At.agda
+++ b/src/Data/List/At.agda
@@ -60,13 +60,13 @@ all-lookup {l = x ∷ l} {suc i} p (px ∷ q) = all-lookup p q
 ∷ʳ[length] [] y = refl
 ∷ʳ[length] (x ∷ Σ) y = ∷ʳ[length] Σ y
 
-pointwise-lookup : ∀ {a b ℓ A B P l m i x} → Rel {a} {b} {ℓ} {A} {B} P l m →
+pointwise-lookup : ∀ {a b ℓ A B P l m i x} → Pointwise {a} {b} {ℓ} {A} {B} P l m →
                     l [ i ]= x → ∃ λ y → m [ i ]= y × P x y
 pointwise-lookup [] ()
 pointwise-lookup {i = zero} (x∼y ∷ q) refl = _ , refl , x∼y
 pointwise-lookup {i = suc i} (x∼y ∷ q) p = pointwise-lookup q p
 
-pointwise-lookup′ : ∀ {a b ℓ A B P l m i x y} → Rel {a} {b} {ℓ} {A} {B} P l m →
+pointwise-lookup′ : ∀ {a b ℓ A B P l m i x y} → Pointwise {a} {b} {ℓ} {A} {B} P l m →
                     l [ i ]= x → m [ i ]= y → P x y
 pointwise-lookup′ [] () q
 pointwise-lookup′ {i = zero} (x∼y ∷ z) refl refl = x∼y

--- a/src/Data/List/First.agda
+++ b/src/Data/List/First.agda
@@ -31,7 +31,7 @@ find P dec [] = no (λ{ (e , ()) })
 find P dec (x ∷ v) with dec x
 find P dec (x ∷ v) | yes px = yes (x , here px)
 find P dec (x ∷ v) | no ¬px with find P dec v
-find P dec (x ∷ v) | no ¬px | yes firstv = yes (, there x ¬px (proj₂ firstv))
+find P dec (x ∷ v) | no ¬px | yes firstv = yes (_ , there x ¬px (proj₂ firstv))
 find P dec (x ∷ v) | no ¬px | no ¬firstv = no $ helper ¬px ¬firstv
   where
     helper : ¬ (P x) → ¬ (∃ λ e → First P e v) → ¬ (∃ λ e → First P e (x ∷ v))

--- a/src/Data/List/Most.agda
+++ b/src/Data/List/Most.agda
@@ -2,9 +2,9 @@ module Data.List.Most where
 
 open import Data.List as List hiding (null) public
 open import Data.List.At public
-open import Data.List.All hiding (zip; unzip; all; tabulate) renaming (lookup to lookup-all; map to map-all) public
+open import Data.List.All hiding (zip; unzip; all; tabulate) renaming (head to head-all ; tail to tail-all ; lookup to lookup-all; map to map-all) public
 open import Data.List.All.Properties.Extra public
-open import Data.List.Any hiding (any; tail) renaming (map to map-any) public
+open import Data.List.Any hiding (any; tail; satisfiable) renaming (map to map-any) public
 open import Data.List.Membership.Propositional public
 open import Data.List.First.Properties public
 open import Data.List.Prefix public


### PR DESCRIPTION
These changes make stdlib++ compile using the most recent version of agda-stdlib (af18282).